### PR TITLE
Back to top or reload document upon clicking bashaway logo

### DIFF
--- a/apps/2025/src/components/common/layout/header.jsx
+++ b/apps/2025/src/components/common/layout/header.jsx
@@ -44,7 +44,8 @@ const Header = ({ className }) => {
             to="/"
             onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
             aria-label="Home"
-            className="hidden xsm:block ">
+            className="hidden xsm:block"
+            reloadDocument={window.scrollY === 0}>
             <Bashaway width={160} className="w-[140px] sm:w-[160px]" />
           </Link>
           <Times height="12px" width="12px" className="hidden xsm:block opacity-20" />


### PR DESCRIPTION
The back to top feature was already there, however there were some issues (mentioned in #47)

This PR will fix those issues by,
- Correctly handling conditional logic with tailwind  classes (there was a `pointer-events-none` class in a wrong conditional branch which made clicks not work. This took some time to figure out :sweat_smile: )
- Brought the logo to top. It was hidden behind hamburger menu stuff in mobile view
- Only addition was making the page refresh if we are already on top
closes #47 

