### PR TITLE
Fix: header links now scroll to correct location on mobile view

### DIFF
--- a/apps/2025/src/components/common/layout/header.jsx
+++ b/apps/2025/src/components/common/layout/header.jsx
@@ -25,7 +25,7 @@ const Header = ({ className }) => {
     setTimeout(() => {
       const element = document.getElementById(path);
       if (element && headerRef.current) {
-        window.scrollTo({ top: element.offsetTop - headerRef.current.offsetHeight, behavior: 'smooth' });
+        window.scrollTo({ top: element.offsetTop - headerRef.current.offsetHeight - 10, behavior: 'smooth' });
       }
     }, 0);
   };

--- a/apps/2025/src/components/common/layout/header.jsx
+++ b/apps/2025/src/components/common/layout/header.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { RxCross1, RxHamburgerMenu } from 'react-icons/rx';
 import { Link } from 'react-router-dom';
 import { twMerge } from 'tailwind-merge';
@@ -15,20 +15,24 @@ const mobileNavIconStyles =
 
 const Header = ({ className }) => {
   const [mobileNavOpen, setMobileNavOpen] = useState(false);
+  const headerRef = useRef(null);
 
   const { didCountDownComplete } = useCountdown({ targetDate: TIME_REGISTRATION_CLOSING });
   const breakpoints = useBreakpoint();
 
   const onNavItemClick = (path) => {
     if (!breakpoints['xl']) setMobileNavOpen(false);
-    window.scrollTo({
-      top: document.getElementById(path).offsetTop - 138,
-      behavior: 'smooth'
-    });
+    setTimeout(() => {
+      const element = document.getElementById(path);
+      if (element && headerRef.current) {
+        window.scrollTo({ top: element.offsetTop - headerRef.current.offsetHeight, behavior: 'smooth' });
+      }
+    }, 0);
   };
 
   return (
     <header
+      ref={headerRef}
       className={twMerge(
         `w-full min-h-[70px] backdrop-blur-md sticky top-0 z-[200] transition-all duration-long`,
         className,


### PR DESCRIPTION
When we call setMobileNavOpen(false), React doesn't immediately update the component and shrink the header. Instead, it schedules that update to happen asynchronously.

The problem was that our code immediately tried to calculate the scroll position in the very next line. At that moment, the re-render hadn't happened yet, so the header was still full-screen. The browser calculated the scroll position based on that old layout.

Then, after the scroll started, React would finally re-render, the header would shrink, and the page would land in the wrong spot.

So after trying several methods, i wrapped the scroll logic in a setTimeout. This pushes the calculation to the back of the execution queue, ensuring it only runs after React has finished its re-render and the header has already collapsed to its final height.

Also, now we get the header's actual height from DOM instead of hardcoding it... Hope it's solved now 😪